### PR TITLE
always allow format_csv_null_representation

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -408,7 +408,8 @@ func (s *scope) decorateRequest(req *http.Request) (*http.Request, url.Values) {
 	origParams := req.URL.Query()
 	for _, param := range allowedParams {
 		val := origParams.Get(param)
-		if len(val) > 0 {
+		// always allow format_csv_null_representation 
+		if len(val) > 0 && param != "format_csv_null_representation" {
 			params.Set(param, val)
 		}
 	}

--- a/scope.go
+++ b/scope.go
@@ -409,7 +409,7 @@ func (s *scope) decorateRequest(req *http.Request) (*http.Request, url.Values) {
 	for _, param := range allowedParams {
 		val := origParams.Get(param)
 		// always allow format_csv_null_representation 
-		if len(val) > 0 && param != "format_csv_null_representation" {
+		if len(val) > 0 || param == "format_csv_null_representation" {
 			params.Set(param, val)
 		}
 	}


### PR DESCRIPTION
I spent more time trying to make exports work in beta, than this. 
Exports work now (it was a missing SSM chproxy parameter) and exports have empty spaces now. e.g. attached customer export from my beta account. 
[1-customer_list-george-test-8e032214-8d79-4d67-a390-60d73037ac26.csv](https://github.com/chartmogul/chproxy/files/14500601/1-customer_list-george-test-8e032214-8d79-4d67-a390-60d73037ac26.csv)

